### PR TITLE
Update ask_qwen for model selection

### DIFF
--- a/scripts/ask_qwen.py
+++ b/scripts/ask_qwen.py
@@ -1,12 +1,22 @@
-import sys
+import argparse
 from openai import OpenAI
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description="Query a local Qwen model")
+    parser.add_argument(
+        "-m",
+        "--model",
+        default="qwen3:0.6b",
+        help="Ollama model identifier",
+    )
+    parser.add_argument("prompt", nargs="*", help="Prompt text")
+    args = parser.parse_args()
+
     client = OpenAI(base_url="http://localhost:11434/v1", api_key="ollama")
-    prompt = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else input("qwen0.6b> ")
+    prompt = " ".join(args.prompt) if args.prompt else input(f"{args.model}> ")
     response = client.chat.completions.create(
-        model="qwen3:0.6b",
+        model=args.model,
         messages=[{"role": "user", "content": prompt}],
     )
     print(response.choices[0].message.content)


### PR DESCRIPTION
## Summary
- allow choosing the Ollama model for `ask_qwen`

## Testing
- `bash scripts/run_tests.sh`
- `python scripts/ask_qwen.py -m qwen3:4b "What is the capital of Japan?"` *(fails: model not found)*