### PR TITLE
Ensure tests pass

### DIFF
--- a/tests/test_docs_vector.py
+++ b/tests/test_docs_vector.py
@@ -53,10 +53,7 @@ def test_index_docs_success(tmp_path: Path, client: httpx.Client):
         f"USE NS test DB test; SELECT text FROM docs_test WHERE embedding <|3|> {vec} LIMIT 1;",
     )
     texts = [
-        row["text"]
-        for item in data
-        if item.get("result")
-        for row in item["result"]
+        row["text"] for item in data if item.get("result") for row in item["result"]
     ]
     assert sample.read_text() in texts
 


### PR DESCRIPTION
## Summary
- run tests again and ensure formatting passes
- format docs vector test with black

## Testing
- `ruff check .`
- `black --check .`
- `bash scripts/run_tests.sh`